### PR TITLE
Fix logo bouncing around

### DIFF
--- a/style.css
+++ b/style.css
@@ -177,12 +177,10 @@ a.btn-filled:hover {
 
 .header a:hover {
     color: #6DAE0C;
-    padding: 10px 25px;
 }
 
 .header a:active {
     color: #6DAE0C;
-    padding: 10px 25px;
 }
 
 


### PR DESCRIPTION
Fixes logo bouncing around by removing old CSS that changes padding when active.

Closes #14 